### PR TITLE
Changes prepublish script to not run on npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "rollup -c",
     "clean": "rm -rf dist",
-    "prepublish": "npm run clean && npm run build",
+    "prepublishOnly": "npm run clean && npm run build",
     "test": "mocha --require babel-register --recursive"
   },
   "repository": "https://github.com/CondeNast/xml-to-react",


### PR DESCRIPTION
the prepublish script currently runs on `npm install`, even though is requires dependencies to be installed.