### PR TITLE
Add eslint for jsdoc and cleanup issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,5 +11,39 @@ module.exports = {
   },
   env: {
     mocha: true,
+  },
+  plugins: [
+    'jsdoc'
+  ],
+  rules: {
+    /**
+     * All available rules are enabled to 'error' by default to encourage more
+     * thorough and accurate documentation
+     * @see https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules
+     */
+    'jsdoc/check-param-names': 'error',
+    'jsdoc/check-tag-names': 'error',
+    'jsdoc/check-types': 'error',
+    'jsdoc/newline-after-description': 'error',
+
+    /**
+     * At present, we are not imposing the "description-complete-sentence" rule
+     * as it will result in a very large number of warnings across all repos.
+     * @see https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-description-complete-sentence
+     */
+    'jsdoc/require-description-complete-sentence': 'off',
+    'jsdoc/require-hyphen-before-param-description': 'error',
+    'jsdoc/require-param': 'error',
+    'jsdoc/require-param-description': 'error',
+    'jsdoc/require-returns-description': 'error',
+    'jsdoc/require-returns-type': 'error'
+  },
+  settings: {
+    jsdoc: {
+      tagNamePreference: {
+        augments: 'extends',
+        return: 'returns'
+      }
+    }
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "8.5.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.7.tgz",
-      "integrity": "sha512-+1ZfzGIq8Y3EV7hPF7bs3i+Gi2mqYOiEGGRxGYPrn+hTYLMmzg+/5TkMkCHiRtLB38XSNvr/43aQ9+cUq4BbBg==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.3.0.tgz",
+      "integrity": "sha512-wNBfvNjzsJl4tswIZKXCFQY0lss9nKUyJnG6T94X/eqjRgI2jHZ4evdjhQYBSan/vGtF6XVXPApOmNH2rf0KKw==",
       "dev": true
     },
     "acorn": {
@@ -797,9 +797,9 @@
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-exponentiation-operator": "6.24.1",
         "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.11.0",
+        "browserslist": "2.11.3",
         "invariant": "2.2.2",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "babel-preset-es2015": {
@@ -974,23 +974,6 @@
         "repeat-element": "1.1.2"
       }
     },
-    "browser-resolve": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
-      "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
-      "dev": true,
-      "requires": {
-        "resolve": "1.1.7"
-      },
-      "dependencies": {
-        "resolve": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
-        }
-      }
-    },
     "browser-stdout": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
@@ -998,13 +981,13 @@
       "dev": true
     },
     "browserslist": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.0.tgz",
-      "integrity": "sha512-mNYp0RNeu1xueGuJFSXkU+K0nH+dBE/gcjtyhtNKfU8hwdrVIfoA7i5iFSjOmzkGdL2QaO7YX9ExiVPE7AY9JA==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
+      "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000789",
-        "electron-to-chromium": "1.3.30"
+        "caniuse-lite": "1.0.30000792",
+        "electron-to-chromium": "1.3.31"
       }
     },
     "builtin-modules": {
@@ -1029,9 +1012,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000789",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000789.tgz",
-      "integrity": "sha1-Lj2TeyZxM/Y2Ne9/RB+sZjYPyIk=",
+      "version": "1.0.30000792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000792.tgz",
+      "integrity": "sha1-0M6pgfgRjzlhRxr7tDyaHlu/AzI=",
       "dev": true
     },
     "chai": {
@@ -1045,7 +1028,7 @@
         "deep-eql": "3.0.1",
         "get-func-name": "2.0.0",
         "pathval": "1.1.0",
-        "type-detect": "4.0.5"
+        "type-detect": "4.0.6"
       }
     },
     "chalk": {
@@ -1141,6 +1124,15 @@
       "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
       "dev": true
     },
+    "comment-parser": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.4.2.tgz",
+      "integrity": "sha1-+lo/eAEwcBFIZtx7jpzzF6ljX3Q=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.3.3"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1232,7 +1224,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.5"
+        "type-detect": "4.0.6"
       }
     },
     "deep-is": {
@@ -1339,20 +1331,11 @@
         "domelementtype": "1.3.0"
       }
     },
-    "electron-releases": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/electron-releases/-/electron-releases-2.1.0.tgz",
-      "integrity": "sha512-cyKFD1bTE/UgULXfaueIN1k5EPFzs+FRc/rvCY5tIynefAPqopQEgjr0EzY+U3Dqrk/G4m9tXSPuZ77v6dL/Rw==",
-      "dev": true
-    },
     "electron-to-chromium": {
-      "version": "1.3.30",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.30.tgz",
-      "integrity": "sha512-zx1Prv7kYLfc4OA60FhxGbSo4qrEjgSzpo1/37i7l9ltXPYOoQBtjQxY9KmsgfHnBxHlBGXwLlsbt/gub1w5lw==",
-      "dev": true,
-      "requires": {
-        "electron-releases": "2.1.0"
-      }
+      "version": "1.3.31",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.31.tgz",
+      "integrity": "sha512-XE4CLbswkZgZFn34cKFy1xaX+F5LHxeDLjY1+rsK9asDzknhbrd9g/n/01/acbU25KTsUSiLKwvlLyA+6XLUOA==",
+      "dev": true
     },
     "emoji-regex": {
       "version": "6.5.1",
@@ -1502,7 +1485,7 @@
         "pluralize": "7.0.0",
         "progress": "2.0.0",
         "require-uncached": "1.0.3",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
         "table": "4.0.2",
@@ -1636,6 +1619,16 @@
             "isarray": "1.0.0"
           }
         }
+      }
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-3.3.1.tgz",
+      "integrity": "sha512-bIPBOl5Z1Tv1+U7Sq0DcOydTIpug5zFjefjewxPGEiNootLltTYCvlL0TlfDhjyb+CrJ+4+n4/y8r9tqBtZZ4Q==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "0.4.2",
+        "lodash": "4.17.4"
       }
     },
     "eslint-plugin-jsx-a11y": {
@@ -2738,7 +2731,7 @@
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "validate-npm-package-license": "3.0.1"
       }
     },
@@ -4525,7 +4518,7 @@
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.7"
+        "@types/node": "9.3.0"
       }
     },
     "path-exists": {
@@ -5041,12 +5034,11 @@
       }
     },
     "rollup-plugin-node-resolve": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.0.tgz",
-      "integrity": "sha1-i4l8TDAw1QASd7BRSyXSygloPuA=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.2.tgz",
+      "integrity": "sha512-ZwmMip/yqw6cmDQJuCQJ1G7gw2z11iGUtQNFYrFZHmqadRHU+OZGC3nOXwXu+UTvcm5lzDspB1EYWrkTgPWybw==",
       "dev": true,
       "requires": {
-        "browser-resolve": "1.11.2",
         "builtin-modules": "1.1.1",
         "is-module": "1.0.0",
         "resolve": "1.5.0"
@@ -5115,9 +5107,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
     },
     "setimmediate": {
@@ -5148,9 +5140,9 @@
       "dev": true
     },
     "sinon": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.1.4.tgz",
-      "integrity": "sha512-ISJZDPf8RS2z4/LAgy1gIimAvF9zg9C9ClQhLTWYWm4HBZjo1WELXlVfkudjdYeN+GtQ2uVBe52m0npIV0gDow==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.1.6.tgz",
+      "integrity": "sha1-nLNGvdsYDWioBEKf/hSXjX+v1ik=",
       "dev": true,
       "requires": {
         "diff": "3.3.1",
@@ -5158,14 +5150,14 @@
         "lodash.get": "4.4.2",
         "lolex": "2.3.1",
         "nise": "1.2.0",
-        "supports-color": "4.5.0",
-        "type-detect": "4.0.5"
+        "supports-color": "5.1.0",
+        "type-detect": "4.0.6"
       },
       "dependencies": {
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -5387,9 +5379,9 @@
       }
     },
     "type-detect": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
-      "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.6.tgz",
+      "integrity": "sha512-qZ3bAurt2IXGPR3c57PyaSYEnQiLRwPeS60G9TahElBZsdOABo+iKYch/PhRjSTZJ5/DF08x43XMt9qec2g3ig==",
       "dev": true
     },
     "typedarray": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint": "^4.13.0",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-jsdoc": "^3.2.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.5.1",
     "mocha": "^4.0.1",

--- a/src/XMLToReact.js
+++ b/src/XMLToReact.js
@@ -13,13 +13,14 @@ const parser = new DOMParser({
 });
 
 
-/*
+/**
  * Class representing an XML to React transformer.
  * @public
  */
 export default class XMLToReact {
-  /*
+  /**
    * Create a XML to React converter.
+   *
    * @param {Object} converters - a mapping of tag names to a function
    *                              returning the desired mapping.
    * @public
@@ -34,8 +35,9 @@ export default class XMLToReact {
   }
 
 
-  /*
+  /**
    * Create a XML to React converter.
+   *
    * @param {string} xml - xml to convert
    * @param {Object} [data] - optional data to assist in conversion
    * @returns {Object} - React element tree
@@ -58,4 +60,3 @@ export default class XMLToReact {
     return visitNode(tree.documentElement, 0, this.converters, data);
   }
 }
-

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -3,6 +3,7 @@ import { createElement } from 'react';
 
 /**
  * Validates a given converters input
+ *
  * @param {Object} converters - an object, with functions as values
  * @returns {boolean} - true when converters is valid, and false when it is invalid
  * @private
@@ -26,6 +27,7 @@ export function validateConverters(converters) {
 
 /**
  * Gets map of XML node attributes of a given node.
+ *
  * @param {Object} node - XML node
  * @returns {Array} - list of children XML nodes
  * @private
@@ -54,6 +56,7 @@ export function getAttributes(node) {
 
 /**
  * Gets list of XML nodes which are the child of a given node.
+ *
  * @param {Object} node - XML node
  * @returns {Array} - list of children XML nodes
  * @private
@@ -75,11 +78,12 @@ export function getChildren(node) {
 
 /**
  * Visit XML nodes recursively and convert into React elements.
+ *
  * @param {Object} node - xml node
  * @param {number} index - Node index to be used as the key
  * @param {Object} converters - Map of XML tag names to component generating functions
  * @param {Object} [data] - Optional data to be passed to coverters
- * @return {Object} React element
+ * @returns {Object} React element
  * @private
  */
 export function visitNode(node, index, converters, data) {


### PR DESCRIPTION
~~Expects #13 to be merged first.~~

- Add `eslint-plugin-jsdoc`
- Enable strict rules
- Fix issues
- Rebuild package-lock cleanly to ensure latest

This set of rules is originally used in our (private) config repo:
https://github.com/CondeNast-Copilot/eslint-config-condenast/blob/develop/rules/ext/jsdoc.js

Ideally, we align on lint for all OSS projects (and ideally in-house as well). This means we should either make our config public, or we should use a different public style guide for OSS.

cc @gautamarora @crccheck