### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,14 +18,6 @@ Open a [new issue](https://github.com/CondeNast/xml-to-react/issues/new). Follow
 
 Open a new pull request. Follow the provided template as a guideline.
 
-#### Do you intend to add a new feature or change an existing one?
-
-* Suggest your change by opening a [new issue](https://github.com/CondeNast/xml-to-react/issues/new) and start writing code.
-
-#### Do you have questions about the source code?
-
-Open a [new issue](https://github.com/CondeNast/xml-to-react/issues/new) making sure to include to include a **title and clear description**.
-
 ### Attribution
 These Contributing Guidelines are adapted from the [Atom](https://github.com/atom/atom) Contributing Guidelines,
 available at https://github.com/atom/atom/blob/master/CONTRIBUTING.md and the [Rails](https://github.com/rails/rails/blob/master/CONTRIBUTING.md) Contributing Guidelines available at https://github.com/rails/rails/blob/master/CONTRIBUTING.md.


### PR DESCRIPTION
**Adapted** from [evangelism/open-source/templates/CONTRIBUTING.md](https://github.com/CondeNast/evangelism/blob/master/open-source/templates/CONTRIBUTING.md)

**[Rendered]**

[rendered]: https://github.com/CondeNast/xml-to-react/blob/docs/contributing/CONTRIBUTING.md

@gautamarora I actually made some changes from the template (I can revert them to align) but I might suggest we modify the template:
- Removed some redundant strong markdown within the h4 markers (renders the same in GH and offers no semantic meaning)
- Used title case `CondeNast` in GitHub URLs to conform to how the org is titled
- ~~Email link doesn't require explicit mailto/url in markdown. seems github is smart enough or it's all good with a reference? (not 100% sure about this though... but it matches what we did for the Code of Conduct)~~
  - **update** no, i was wrong! either we use no markdown link or i add the mailto back. i'm going to add the mailto back! ignore this comment!
