### PR TITLE
Create CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+<!--
+## [x.y.z] - YYYY-MM-DD
+### [Type of Change]
+- [description of change]
+
+### Types of changes
+- **Added** for new features.
+- **Changed** for changes in existing functionality.
+- **Deprecated** for soon-to-be removed features.
+- **Removed** for now removed features.
+- **Fixed** for any bug fixes.
+- **Security** in case of vulnerabilities.
+
+[x.y.z]: https://github.com/CondeNast/xml-to-react/compare/1.0.0...x.y.z
+-->
+
+## [Unreleased]
+- Initial Release
+
+<!-- Update the Unreleased comparison range with each release -->
+[Unreleased]: https://github.com/CondeNast/xml-to-react/compare/x.y.z...master


### PR DESCRIPTION
I'm setting up a CHANGELOG based on the [keep a changelog](http://keepachangelog.com/en/1.0.0/) format. I don't have any strong feelings about one standard or another (are there others?) but it's great to have _something_. This is used in some of our other repos.

I'm not sure how to setup the initial CHANGELOG since we haven't published the 1.0.0 version yet (but we could do that right now?)

I feel like there's some value in putting some documentation into a comment block rather than assuming developers will follow the link. I'm not sure.