### PR TITLE
Fix for spy to correctly test the function being called

### DIFF
--- a/test/XMLToReact.test.js
+++ b/test/XMLToReact.test.js
@@ -6,7 +6,7 @@ import { shallow, configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
 import XMLToReact from '../src/XMLToReact';
-import { visitNode } from '../src/helpers';
+import * as helpers from '../src/helpers';
 
 configure({ adapter: new Adapter() });
 
@@ -65,7 +65,7 @@ describe('XMLToReact class ', () => {
     let visitNodeSpy;
 
     before(() => {
-      visitNodeSpy = sandbox.spy(visitNode);
+      visitNodeSpy = sandbox.spy(helpers, 'visitNode');
     });
 
     beforeEach(() => {
@@ -105,6 +105,7 @@ describe('XMLToReact class ', () => {
       const tree = xmltoreact.convert(mockXML);
 
       expect(tree).to.equal(null);
+      expect(visitNodeSpy.called).to.equal(true);
     });
 
     it('returns a React element tree with valid, simple XML without data', () => {
@@ -114,6 +115,7 @@ describe('XMLToReact class ', () => {
       const tree = xmltoreact.convert(mockXML);
 
       expect(tree).not.to.equal(null);
+      expect(visitNodeSpy.called).to.equal(true);
 
       const wrapper = shallow(tree);
 
@@ -133,11 +135,13 @@ describe('XMLToReact class ', () => {
       const tree = xmltoreact.convert(mockXML);
 
       expect(tree).not.to.equal(null);
+      expect(visitNodeSpy.called).to.equal(true);
 
       const wrapper = shallow(tree);
 
       expect(wrapper.exists()).to.equal(true);
       expect(wrapper.find('.test > [fancy]')).to.have.length(1);
+      expect(visitNodeSpy.called).to.equal(true);
     });
 
     it('returns a React element tree with valid XML and valid data', () => {
@@ -146,6 +150,7 @@ describe('XMLToReact class ', () => {
       const tree = xmltoreact.convert(mockXML, mockData);
 
       expect(tree).not.to.equal(null);
+      expect(visitNodeSpy.called).to.equal(true);
 
       const wrapper = shallow(tree);
 
@@ -161,6 +166,7 @@ describe('XMLToReact class ', () => {
           const tree = xmltoreact.convert(mockXML, badData);
 
           expect(tree).not.to.equal(null);
+          expect(visitNodeSpy.called).to.equal(true);
 
           const wrapper = shallow(tree);
 
@@ -170,4 +176,3 @@ describe('XMLToReact class ', () => {
       });
   });
 });
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR fixes the sinon setup to correctly test for the spy to test when it is being called, and when it is not being called.

## Description
<!--- Describe your changes in detail -->
The sinon setup was incomplete for cases to actually test when the visitNode spy was being called. On adding that, I noticed that the spy was not ever being called. This PR fixes the issue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore, documentation, cleanup

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->
`npm test` - all unit tests pass

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
