### PR TITLE
chore: update output name key within rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,10 +8,10 @@ const pkg = require('./package.json');
 export default [
 
   {
-    name: 'XMLToReact',
     input: 'src/XMLToReact.js',
     output: [
       {
+        name: 'XMLToReact',
         file: pkg.browser,
         format: 'umd',
         globals: {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore, documentation, cleanup


## Motivation and Context
A deprecation warning is being thrown asking us to move the config key.
The warning links to the following gist:
https://gist.github.com/Rich-Harris/d472c50732dab03efeb37472b08a3f32

## How Has This Been Tested?
- `$ npm run build`
- Verify you do not get a deprecated config option warning
- Verify build browser bundle has it's module name is `XMLToReact`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
