### PR TITLE
Add node_modules directory to .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 .git
 coverage
 dist
+node_modules


### PR DESCRIPTION
This change adds `node_modules/` as a directory that will be ignored when the we run the linter.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore, documentation, cleanup

## Motivation and Context
Currently, running `eslint .` throws an error related to a dependency.

## How Has This Been Tested?
Ran `npm test`, verified no issues are found.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
